### PR TITLE
Allow for 'Coins Weight Extension' in the Inventory Item Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It has been tested with the CoreRPG, Pathfinder 1e, D&D 3.5E, and 5E rulesets.
 Previous users of [damned](https://www.fantasygrounds.com/forums/member.php?19192-damned)'s [5eCoinWeight extension](https://www.fantasygrounds.com/forums/showthread.php?41109-The-weight-of-the-coins&p=387476&viewfull=1#post387476) will have carried and uncarried coins (from both columns) brought over seamlessly. 
 
 # Features
-It does this by adding a "Coins" inventory item of the appropriate weight and setting the cost of this item to the total value of all coins.
+It does this by adding a "Coins" inventory item of the appropriate weight and setting the cost of this item to the total value of all coins.  If desired, the name of the inventory item can be extended for clarity using "Coins Weight Extension" and it will still be utilzed.  For example: Coins (Coins Weight Extension)
 This "Coins" inventory entry can be marked uncarried or put into a bag of holding (if using my [extraplanar containers](https://www.fantasygrounds.com/forums/showthread.php?67126-PFRPG-Extraplanar-Containers) extension) to negate the weight. If you use this extension with a ruleset that it doesn't have support for yet, it will post a message in the chat with the detected ruleset name. Please include this in any requests for more denominations to be added. To define the weight and value of additional denominations yourself—such as for homebrew currencies—edit the ext file attached to [this post](https://www.fantasygrounds.com/forums/showthread.php?67228-CoreRPG-Coins-Weight&p=588689&viewfull=1#post588689). Ask for help if you need it.
 
 # Included ruleset definitions:

--- a/scripts/coinweight.lua
+++ b/scripts/coinweight.lua
@@ -2,9 +2,6 @@
 --	Please see the LICENSE.md file included with this distribution for attribution and copyright information.
 --
 
--- Used for item name init and also finding the item, constant will never get out of sync.
-COINS_INVENTORY_ITEM_NAME = 'Coins'
-
 ---	This function imports the data from the second column of coins used in damned's coins weight extension.
 --	bmos also used this data structure in an early version of Total Encumbrance.
 --	Once imported, the original database nodes are deleted.
@@ -50,7 +47,7 @@ local function createCoinsItem(nodeChar)
 	local nodeCoinsItem
 	if nodeChar.getParent().getName() == 'charsheet' then
 		nodeCoinsItem = DB.createChild(nodeChar.createChild('inventorylist'))
-		DB.setValue(nodeCoinsItem, 'name', 'string', COINS_INVENTORY_ITEM_NAME)
+		DB.setValue(nodeCoinsItem, 'name', 'string', 'Coins')
 		DB.setValue(nodeCoinsItem, 'type', 'string', 'Wealth and Money')
 		DB.setValue(nodeCoinsItem, 'description', 'formattedtext', Interface.getString("item_description_coins"))
 	end
@@ -63,7 +60,7 @@ end
 local function findCoinsItem(nodeChar)
 	for _,nodeItem in pairs(DB.getChildren(nodeChar, 'inventorylist')) do
 		local sItemName = DB.getValue(nodeItem, 'name', '')
-		if sItemName == COINS_INVENTORY_ITEM_NAME
+		if sItemName == 'Coins'
 		   or string.match(sItemName:lower(), '^%W*coins%W+coins%W+weight%W+extension%W*$') then
 			return nodeItem
 		end

--- a/scripts/coinweight.lua
+++ b/scripts/coinweight.lua
@@ -2,7 +2,7 @@
 --	Please see the LICENSE.md file included with this distribution for attribution and copyright information.
 --
 
--- Used for item name and also finding the item, so use constant so it's never out of sync.
+-- Used for item name init and also finding the item, constant will never get out of sync.
 COINS_INVENTORY_ITEM_NAME = 'Coins'
 
 ---	This function imports the data from the second column of coins used in damned's coins weight extension.

--- a/scripts/coinweight.lua
+++ b/scripts/coinweight.lua
@@ -59,7 +59,7 @@ local function createCoinsItem(nodeChar)
 end
 
 ---	This function looks for the "Coins" inventory item if it already exists.
---- Also matches "Coins (Coins Weight Extension)" for more context in name.
+---	Also matches "Coins (Coins Weight Extension)" for more context in name.
 local function findCoinsItem(nodeChar)
 	for _,nodeItem in pairs(DB.getChildren(nodeChar, 'inventorylist')) do
 		local sItemName = DB.getValue(nodeItem, 'name', '')


### PR DESCRIPTION
Hi bmos.  Feel free to decline the PR if you aren't intersted, but sometimes my players and I forget about the extension and wonder what 'Coins' is in our inventory.  This change will allow for a slightly more obvious name while still working 100% like original.  Here are the details:

The matching will always work in its original way with it matching 'Coins' as a case-sensitive match.

Allow for a more descriptive name that a DM or player will immediately recognize as being used for the extension and not some actual inventory item.  The three words must follow the original 'coins' with any whitespace delimiters.  Some examples of matches are:

Coins (Coins Weight Extension)
Coins - coins weight extension
coins | coins weight extension
Coins; Coins Weight Extension
Coins -- [[Coins Weight Extension]]